### PR TITLE
Fix missing parameter on WGPURenderPassColorAttachment

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdbool.h>
 
 // emscripten
 #include "emscripten.h"
@@ -303,7 +304,8 @@ void draw() {
             .view = back_buffer,
             .loadOp = WGPULoadOp_Clear,
             .storeOp = WGPUStoreOp_Store,
-            .clearValue = (WGPUColor){ 0.2f, 0.2f, 0.3f, 1.0f }
+            .clearValue = (WGPUColor){ 0.2f, 0.2f, 0.3f, 1.0f },
+            .depthSlice = WGPU_DEPTH_SLICE_UNDEFINED
         },
     });
 


### PR DESCRIPTION
### [Problem]
OS: macOS 12.1
Chrome: 125.0.6422.142
Emscripten: 3.1.61
![image](https://github.com/seyhajin/webgpu-wasm-c/assets/26870568/d8a4067c-6294-473e-8597-0ad084d32108)

### [Solution]
![image](https://github.com/seyhajin/webgpu-wasm-c/assets/26870568/aacc0164-f2bc-47ae-b46c-f07057bda67a)

